### PR TITLE
Add test suite for local ONNX workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,37 @@ The script currently supports:
 
 This list can be customized in the `config.json` file.
 
+## Running Locally with ONNX
+
+The organizer can run entirely offline using an ONNX model on a Copilot+ PC. A
+typical workflow is:
+
+1. **Download a model.** Many models are available in ONNX format on
+   [HuggingFace](https://huggingface.co). For example to download the DeepSeek
+   R1 distilled model you can run:
+
+   ```bash
+   huggingface-cli download onnxruntime/DeepSeek-R1-Distill-ONNX \
+     --include "deepseek-r1-distill-qwen-1.5B/*" --local-dir /path/to/model
+   ```
+
+2. **Install the required packages.** `onnxruntime-genai` provides the runtime
+   and will automatically use the QNN execution provider on supported hardware.
+
+   ```bash
+   pip install onnxruntime-genai transformers
+   ```
+
+3. **Run the script.** Pass the model directory and the folder you wish to
+   organize:
+
+   ```bash
+   python local_main.py <input_directory> --model_dir /path/to/model
+   ```
+
+The script detects the Neural Processing Unit through the QNN execution
+provider when available and falls back to CPU otherwise.
+
 ## Contributions
 
 Contributions are welcome! If you have any ideas for improvements, or find bugs, please feel free to open an issue or submit a pull request.

--- a/local_main.py
+++ b/local_main.py
@@ -1,0 +1,81 @@
+import argparse
+import os
+import json
+from pathlib import Path
+import subprocess
+import docx
+import PyPDF2
+from onnx_llm_client import ONNXLLMClient
+
+
+def read_txt(path: Path) -> str:
+    with open(path, "r", encoding="utf-8", errors="ignore") as f:
+        return f.read()
+
+
+def read_docx(path: Path) -> str:
+    try:
+        document = docx.Document(path)
+        return "\n".join(p.text for p in document.paragraphs)
+    except Exception:
+        return ""
+
+
+def read_pdf(path: Path) -> str:
+    try:
+        with open(path, "rb") as f:
+            reader = PyPDF2.PdfReader(f)
+            pages = [page.extract_text() or "" for page in reader.pages]
+        return "\n".join(pages)
+    except Exception:
+        return ""
+
+
+def read_doc(path: Path) -> str:
+    try:
+        result = subprocess.run(["antiword", str(path)], capture_output=True, text=True)
+        if result.returncode == 0:
+            return result.stdout
+    except FileNotFoundError:
+        pass
+    return ""
+
+
+def read_file(path: Path) -> str:
+    ext = path.suffix.lower()
+    if ext in {".txt", ".md"}:
+        return read_txt(path)
+    if ext == ".docx":
+        return read_docx(path)
+    if ext == ".pdf":
+        return read_pdf(path)
+    if ext == ".doc":
+        return read_doc(path)
+    return ""
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Local file organizer using ONNX LLM")
+    parser.add_argument("input_dir", type=Path)
+    parser.add_argument("--model_dir", required=True, type=Path, help="Path to ONNX model")
+    args = parser.parse_args()
+
+    client = ONNXLLMClient(str(args.model_dir))
+
+    SUPPORTED_EXT = {".txt", ".md", ".doc", ".docx", ".pdf"}
+    analysis = {}
+    for file_path in args.input_dir.rglob('*'):
+        if file_path.is_file() and file_path.suffix.lower() in SUPPORTED_EXT:
+            text = read_file(file_path)
+            if text:
+                result = client.analyze_text(text)
+            else:
+                result = {}
+            analysis[str(file_path)] = result
+
+    structure = client.propose_structure(analysis)
+    with open('report.json', 'w') as f:
+        json.dump({"analysis": analysis, "structure": structure}, f, indent=2)
+
+if __name__ == "__main__":
+    main()

--- a/onnx_llm_client.py
+++ b/onnx_llm_client.py
@@ -1,0 +1,43 @@
+import os
+import json
+import onnxruntime_genai as og
+from transformers import AutoTokenizer
+
+class ONNXLLMClient:
+    def __init__(self, model_dir: str):
+        if not os.path.isdir(model_dir):
+            raise FileNotFoundError(f"Model directory not found: {model_dir}")
+        self.model_dir = model_dir
+        self.tokenizer = AutoTokenizer.from_pretrained(model_dir, trust_remote_code=True)
+        self.model = og.Model(model_dir)
+
+    def _generate(self, prompt: str, max_tokens: int = 1024) -> str:
+        params = og.GeneratorParams(self.model)
+        params.set_search_options(max_length=max_tokens, temperature=0.6, top_p=0.95)
+        generator = og.Generator(self.model, params)
+        input_tokens = self.tokenizer.encode(prompt)
+        generator.append_tokens(input_tokens)
+        output_tokens = []
+        while not generator.is_done():
+            generator.generate_next_token()
+            output_tokens.extend(generator.get_next_tokens())
+        return self.tokenizer.decode(output_tokens)
+
+    def analyze_text(self, text: str) -> dict:
+        prompt = (
+            "Analyze the following document and extract key entities, their "
+            "categories and importance. Provide a JSON array with fields: "
+            "entity, category, importance, explanation.\n\nDocument:\n" + text
+        )
+        result = self._generate(prompt)
+        return json.loads(result)
+
+    def propose_structure(self, analysis_results: dict) -> dict:
+        prompt = (
+            "Using the provided analysis results, propose a folder structure "
+            "grouping files by category and importance. Return a JSON object "
+            "where keys are folder names and values are lists of files.\n\n" +
+            json.dumps(analysis_results)
+        )
+        result = self._generate(prompt)
+        return json.loads(result)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ PyPDF2
 tqdm
 jsonschema
 google-genai
+onnxruntime-genai
+transformers
+pytest

--- a/tests/test_local_onnx.py
+++ b/tests/test_local_onnx.py
@@ -1,0 +1,136 @@
+import json
+import os
+import sys
+from pathlib import Path
+import subprocess
+
+import pytest
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import types
+sys.modules.setdefault("onnxruntime_genai", types.SimpleNamespace(Model=object, GeneratorParams=object, Generator=object))
+sys.modules.setdefault("transformers", types.SimpleNamespace(AutoTokenizer=types.SimpleNamespace(from_pretrained=lambda *a, **k: types.SimpleNamespace(encode=lambda x: [], decode=lambda x: ""))))
+
+import local_main
+import onnx_llm_client
+
+
+def test_read_txt(tmp_path):
+    path = tmp_path / "test.txt"
+    path.write_text("hello")
+    assert local_main.read_txt(path) == "hello"
+
+
+def test_read_docx(tmp_path):
+    doc_path = tmp_path / "test.docx"
+    import docx
+    document = docx.Document()
+    document.add_paragraph("hello world")
+    document.save(doc_path)
+    text = local_main.read_docx(doc_path)
+    assert "hello world" in text
+
+
+def test_read_pdf(tmp_path):
+    pdf_path = tmp_path / "test.pdf"
+    from PyPDF2 import PdfWriter
+    writer = PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+    with open(pdf_path, 'wb') as f:
+        writer.write(f)
+    # a blank pdf should return an empty string
+    assert local_main.read_pdf(pdf_path) == ""
+
+
+def test_read_doc(monkeypatch):
+    def fake_run(args, capture_output, text):
+        class R:
+            returncode = 0
+            stdout = "dummy"
+        return R()
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    assert local_main.read_doc(Path("a.doc")) == "dummy"
+
+
+def test_read_doc_no_antiword(monkeypatch):
+    def fake_run(args, capture_output, text):
+        raise FileNotFoundError
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    assert local_main.read_doc(Path("a.doc")) == ""
+
+
+def test_read_file_dispatch(tmp_path, monkeypatch):
+    txt = tmp_path / "a.txt"
+    txt.write_text("hi")
+    assert local_main.read_file(txt) == "hi"
+
+    docx_path = tmp_path / "b.docx"
+    import docx as docx_module
+    d = docx_module.Document()
+    d.add_paragraph("hi")
+    d.save(docx_path)
+    assert "hi" in local_main.read_file(docx_path)
+
+    pdf = tmp_path / "c.pdf"
+    from PyPDF2 import PdfWriter
+    w = PdfWriter()
+    w.add_blank_page(width=72, height=72)
+    with open(pdf, 'wb') as f:
+        w.write(f)
+    assert local_main.read_file(pdf) == ""
+
+
+def test_onnx_client_analyze(monkeypatch, tmp_path):
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+
+    def fake_init(self, model_dir):
+        self.model_dir = model_dir
+    monkeypatch.setattr(onnx_llm_client.ONNXLLMClient, "__init__", fake_init)
+
+    client = onnx_llm_client.ONNXLLMClient(str(model_dir))
+    monkeypatch.setattr(client, "_generate", lambda prompt, max_tokens=1024: '[{"k":1}]')
+    assert client.analyze_text("text") == [{"k": 1}]
+
+
+def test_onnx_client_propose(monkeypatch, tmp_path):
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+
+    def fake_init(self, model_dir):
+        self.model_dir = model_dir
+    monkeypatch.setattr(onnx_llm_client.ONNXLLMClient, "__init__", fake_init)
+
+    client = onnx_llm_client.ONNXLLMClient(str(model_dir))
+    monkeypatch.setattr(client, "_generate", lambda prompt, max_tokens=1024: '{"folder": []}')
+    assert client.propose_structure({}) == {"folder": []}
+
+
+def test_main_integration(tmp_path, monkeypatch):
+    input_dir = tmp_path / "files"
+    input_dir.mkdir()
+    (input_dir / "f.txt").write_text("hello")
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+
+    class FakeClient:
+        def __init__(self, md):
+            pass
+        def analyze_text(self, text):
+            return {"summary": "ok"}
+        def propose_structure(self, analysis):
+            return {"folder": list(analysis.keys())}
+
+    monkeypatch.setattr(local_main, "ONNXLLMClient", FakeClient)
+
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        sys.argv = ["local_main.py", str(input_dir), "--model_dir", str(model_dir)]
+        local_main.main()
+    finally:
+        os.chdir(cwd)
+    report = tmp_path / "report.json"
+    assert report.exists()
+    data = json.loads(report.read_text())
+    assert "analysis" in data and "structure" in data
+


### PR DESCRIPTION
## Summary
- add automated tests covering ONNX file readers, ONNX LLM client and local main workflow
- include pytest in requirements

## Testing
- `python -m py_compile onnx_llm_client.py local_main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6846e273dc14832aba17182702926493